### PR TITLE
Bump version of tmp-proc

### DIFF
--- a/tmp-proc/ChangeLog.md
+++ b/tmp-proc/ChangeLog.md
@@ -2,6 +2,12 @@
 
 `tmp-proc` uses [PVP Versioning][1].
 
+## 0.5.2.0 -- 2023-07-12
+
+* Bump minimum required version of warp-tls
+* Refactor/Disable tests to avoid direct/indirect dependencies on
+  Network.Connection
+
 ## 0.5.1.4 -- 2023-07-12
 
 * Extend the version bounds of bytestring to allow 0.12

--- a/tmp-proc/tmp-proc.cabal
+++ b/tmp-proc/tmp-proc.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               tmp-proc
-version:            0.5.1.4
+version:            0.5.2.0
 synopsis:           Run 'tmp' processes in integration tests
 description:
   @tmp-proc@ runs services in docker containers for use in integration tests.


### PR DESCRIPTION
To provide a hackage version with no dependency on the lost package, connection