### PR TITLE
bump lower bounds to reflect tmp-proc API changes

### DIFF
--- a/tmp-proc-postgres/tmp-proc-postgres.cabal
+++ b/tmp-proc-postgres/tmp-proc-postgres.cabal
@@ -35,7 +35,7 @@ library
     , bytestring         >=0.10.8.2 && <0.12.1
     , postgresql-simple  >=0.5.4  && <0.8
     , text               >=1.2.3.0  && <1.3 || >=2.0 && <2.1
-    , tmp-proc           >=0.5  && <0.6
+    , tmp-proc           >=0.5.3  && <0.6
 
   default-language: Haskell2010
   ghc-options:      -fno-ignore-asserts -Wall

--- a/tmp-proc-rabbitmq/tmp-proc-rabbitmq.cabal
+++ b/tmp-proc-rabbitmq/tmp-proc-rabbitmq.cabal
@@ -36,7 +36,7 @@ library
     , base        >=4.11     && <5
     , bytestring  >=0.10.8.2 && <0.12.1
     , text        >=1.2.3 && <2.2
-    , tmp-proc    >=0.5.2 && <0.6
+    , tmp-proc    >=0.5.3 && <0.6
 
   default-language: Haskell2010
   ghc-options:      -fno-ignore-asserts -Wall

--- a/tmp-proc-redis/tmp-proc-redis.cabal
+++ b/tmp-proc-redis/tmp-proc-redis.cabal
@@ -36,7 +36,7 @@ library
     , bytestring  >=0.10.8.2 && <0.12.1
     , hedis       >=0.10.4   && <0.16
     , text        >=1.2.3 && <2.2
-    , tmp-proc    >=0.5  && <0.6
+    , tmp-proc    >=0.5.3  && <0.6
 
   default-language: Haskell2010
   ghc-options:      -fno-ignore-asserts -Wall

--- a/tmp-proc-zipkin/tmp-proc-zipkin.cabal
+++ b/tmp-proc-zipkin/tmp-proc-zipkin.cabal
@@ -36,7 +36,7 @@ library
     , bytestring   >=0.10.8.2 && <0.12.1
     , http-client  >=0.5.13.1 && <0.8.0.0
     , text         >=1.2.3 && <2.2
-    , tmp-proc     >=0.5  && <0.6
+    , tmp-proc     >=0.5.3  && <0.6
     , tracing      >=0.0.7.2  && <0.1.0
 
   default-language: Haskell2010


### PR DESCRIPTION
## Description

exactly what it says: the sub-projects take advantage of the `only` constructor introduced in `tmp-proc-0.5.3` but don't have lower bounds that reflect this.