### PR TITLE
Converts the ProcHandle constructor to a PatternSynonym

### DIFF
--- a/tmp-proc-postgres/src/System/TmpProc/Docker/Postgres.hs
+++ b/tmp-proc-postgres/src/System/TmpProc/Docker/Postgres.hs
@@ -124,7 +124,7 @@ toPinged action =
 
 -- | Empty all rows in the tables, if any are specified.
 reset' :: ProcHandle TmpPostgres -> IO ()
-reset' handle@ProcHandle {hProc = hProc} =
+reset' handle@ProcHandle {hProc} =
   let go (TmpPostgres []) = pure ()
       go (TmpPostgres tables) = withTmpConn handle $ \c ->
         mapM_ (execute_ c . (fromString . (++) "DELETE FROM ") . Text.unpack) tables

--- a/tmp-proc-postgres/src/System/TmpProc/Docker/Postgres.hs
+++ b/tmp-proc-postgres/src/System/TmpProc/Docker/Postgres.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -124,8 +123,8 @@ toPinged action =
 
 -- | Empty all rows in the tables, if any are specified.
 reset' :: ProcHandle TmpPostgres -> IO ()
-reset' handle@(ProcHandle {hProc}) =
+reset' handle =
   let go (TmpPostgres []) = pure ()
       go (TmpPostgres tables) = withTmpConn handle $ \c ->
         mapM_ (execute_ c . (fromString . (++) "DELETE FROM ") . Text.unpack) tables
-   in go hProc
+   in go $ hProc handle

--- a/tmp-proc-postgres/src/System/TmpProc/Docker/Postgres.hs
+++ b/tmp-proc-postgres/src/System/TmpProc/Docker/Postgres.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -123,8 +124,8 @@ toPinged action =
 
 -- | Empty all rows in the tables, if any are specified.
 reset' :: ProcHandle TmpPostgres -> IO ()
-reset' handle =
+reset' handle@ProcHandle {hProc = hProc} =
   let go (TmpPostgres []) = pure ()
       go (TmpPostgres tables) = withTmpConn handle $ \c ->
         mapM_ (execute_ c . (fromString . (++) "DELETE FROM ") . Text.unpack) tables
-   in go $ hProc handle
+   in go hProc

--- a/tmp-proc-rabbitmq/src/System/TmpProc/Docker/RabbitMQ.hs
+++ b/tmp-proc-rabbitmq/src/System/TmpProc/Docker/RabbitMQ.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/tmp-proc-redis/src/System/TmpProc/Docker/Redis.hs
+++ b/tmp-proc-redis/src/System/TmpProc/Docker/Redis.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -116,7 +117,7 @@ mkUri' ip = "redis://" <> C8.pack (Text.unpack ip) <> "/"
 
 
 clearKeys :: ProcHandle TmpRedis -> IO ()
-clearKeys handle =
+clearKeys handle@ProcHandle {hProc} =
   let go (TmpRedis []) = pure ()
       go (TmpRedis keys) = withTmpConn handle $ \c -> runRedis c $ void $ del keys
-   in go $ hProc handle
+   in go hProc

--- a/tmp-proc-redis/src/System/TmpProc/Docker/Redis.hs
+++ b/tmp-proc-redis/src/System/TmpProc/Docker/Redis.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -117,7 +116,7 @@ mkUri' ip = "redis://" <> C8.pack (Text.unpack ip) <> "/"
 
 
 clearKeys :: ProcHandle TmpRedis -> IO ()
-clearKeys handle@(ProcHandle {hProc}) =
+clearKeys handle =
   let go (TmpRedis []) = pure ()
       go (TmpRedis keys) = withTmpConn handle $ \c -> runRedis c $ void $ del keys
-   in go hProc
+   in go $ hProc handle

--- a/tmp-proc/ChangeLog.md
+++ b/tmp-proc/ChangeLog.md
@@ -2,6 +2,10 @@
 
 `tmp-proc` uses [PVP Versioning][1].
 
+## 0.7.0.0 -- Unreleased
+
+# Convert ProcHandle constructor into a unidirectional PatternSynonym 
+
 ## 0.6.2.1 -- 2024-04-21
 
 * Fix formatting in the cabal description

--- a/tmp-proc/src/System/TmpProc/Docker.hs
+++ b/tmp-proc/src/System/TmpProc/Docker.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -80,7 +81,7 @@ module System.TmpProc.Docker
   , withTmpProcs
 
     -- * access a started @'Proc'@
-  , ProcHandle (..)
+  , ProcHandle (ProcHandle, hUri, hPid, hAddr, hProc)
   , SlimHandle (..)
   , Proc2Handle
   , HasHandle
@@ -213,12 +214,31 @@ withTmpProcs procs action =
 
 
 -- | Provides access to a 'Proc' that has been started.
-data ProcHandle a = ProcHandle
-  { hProc :: !a
-  , hPid :: !String
-  , hUri :: !SvcURI
-  , hAddr :: !HostIpAddress
+data ProcHandle a = MkProcHandle
+  { mphProc :: !a
+  , mphPid :: !String
+  , mphUri :: !SvcURI
+  , mphAddr :: !HostIpAddress
   }
+
+
+{- | A @pattern@ constructor the provides selectors for the @ProcHandle@ fields
+
+The selectors are readonly, i.e they only match in pattern context since
+@ProcHandle@s cannot be constructed directly; they are obtained@ through
+'startupAll' or 'startup'
+-}
+pattern ProcHandle ::
+  -- | the 'Proc' that specified this @ProcHandle@
+  a ->
+  -- | the docker process ID corresponding to the started container
+  String ->
+  -- | the URI to the test service instance
+  SvcURI ->
+  -- | the IP address of the test service instance
+  HostIpAddress ->
+  ProcHandle a
+pattern ProcHandle {hProc, hPid, hUri, hAddr} <- MkProcHandle hProc hPid hUri hAddr
 
 
 -- | Provides an untyped view of the data in a 'ProcHandle'
@@ -515,18 +535,18 @@ startup' ntwkMb addrs x = do
       trim = dropWhileEnd isGarbage . dropWhile isGarbage
   printDebug $ Text.pack $ show fullArgs
   runCmd <- createDockerCmdProcess fullArgs
-  hPid <- trim <$> readCreateProcess runCmd ""
-  hAddr <-
+  mphPid <- trim <$> readCreateProcess runCmd ""
+  mphAddr <-
     Text.pack . trim
       <$> readProcess
         "docker"
         [ "inspect"
-        , hPid
+        , mphPid
         , "--format"
         , "'{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'"
         ]
         ""
-  let h = ProcHandle {hProc = x, hPid, hUri = uriOf' x hAddr, hAddr}
+  let h = MkProcHandle {mphProc = x, mphPid, mphUri = uriOf' x mphAddr, mphAddr}
   (nPings h `onException` terminate h) >>= \case
     OK -> pure h
     pinged -> do
@@ -555,8 +575,9 @@ toPinged _ action =
 
 -- | Ping a 'ProcHandle' several times.
 nPings :: (Proc a) => ProcHandle a -> IO Pinged
-nPings h@ProcHandle {hProc = p} =
+nPings h =
   let
+    p = hProc h
     count = fromEnum $ pingCount' p
     gap = fromEnum $ pingGap' p
 

--- a/tmp-proc/src/System/TmpProc/Docker.hs
+++ b/tmp-proc/src/System/TmpProc/Docker.hs
@@ -229,7 +229,7 @@ The selectors are readonly, i.e they only match in pattern context since
 'startupAll' or 'startup'
 -}
 pattern ProcHandle ::
-  -- | the 'Proc' that specified this @ProcHandle@
+  -- | the 'Proc' that led to this @ProcHandle@
   a ->
   -- | the docker process ID corresponding to the started container
   String ->
@@ -239,6 +239,9 @@ pattern ProcHandle ::
   HostIpAddress ->
   ProcHandle a
 pattern ProcHandle {hProc, hPid, hUri, hAddr} <- MkProcHandle hProc hPid hUri hAddr
+
+
+{-# COMPLETE ProcHandle #-}
 
 
 -- | Provides an untyped view of the data in a 'ProcHandle'


### PR DESCRIPTION
- and makes the selectors 'readonly', i.e, only available for pattern-matching or selection